### PR TITLE
Accordion menu no longer renders empty sections

### DIFF
--- a/src/assets/data/dishes.json
+++ b/src/assets/data/dishes.json
@@ -17,7 +17,7 @@
         "price": 50,
         "cover_image": "https://tmbidigitalassetsazure.blob.core.windows.net/rms3-prod/attachments/37/1200x1200/All-American-Bacon-Cheeseburgers_exps48107_TH2379798C03_29_1b_RMS.jpg",
         "categories": [0],
-        "course": 1,
+        "course": 0,
         "isTodaysSpecial": false
     },
 

--- a/src/components/AccordionMenu.vue
+++ b/src/components/AccordionMenu.vue
@@ -5,16 +5,16 @@
         <div class="content">
             <v-expansion-panels accordion v-if="Object.keys(dishesByCourse).length > 0">
                 <v-expansion-panel v-for="(course, i) in dishesByCourse" :key="i">
-                    <v-expansion-panel-header>{{course.name}}</v-expansion-panel-header>
-                    <v-expansion-panel-content>
-                        <Dish v-for="dish in course.dishes" :key="dish.id"
-                        :title="dish.title"
-                        :image="dish.cover_image"
-                        :description="dish.description"
-                        :price="dish.price"
-                        :ingredients="dish.ingredients"
-                        ></Dish>
-                    </v-expansion-panel-content>
+                        <v-expansion-panel-header>{{course.name}}</v-expansion-panel-header>
+                        <v-expansion-panel-content>
+                            <Dish v-for="dish in course.dishes" :key="dish.id"
+                            :title="dish.title"
+                            :image="dish.cover_image"
+                            :description="dish.description"
+                            :price="dish.price"
+                            :ingredients="dish.ingredients"
+                            ></Dish>
+                        </v-expansion-panel-content>
                 </v-expansion-panel>
             </v-expansion-panels>
             <h3 v-else-if="isLoading">Loading...</h3>
@@ -60,6 +60,11 @@ export default {
                 filteredDishes[dish.course].dishes.push(dish);
             });
 
+            Object.keys(filteredDishes).forEach(course => {
+                if(filteredDishes[course].dishes.length === 0){
+                    delete filteredDishes[course];
+                }
+            });
             return filteredDishes;
         }
     }

--- a/tests/unit/accordionMenu.test.js
+++ b/tests/unit/accordionMenu.test.js
@@ -9,6 +9,18 @@ import { vuetifyConfig } from '@/plugins/vuetifyConfig';
 describe("Menu", () => {
 
     let app;
+
+    const courses = [{
+        "id": 0,
+        "name": "Starters",
+        "slug": "starters"
+    },
+    {
+        "id": 1,
+        "name": "Soup",
+        "slug": "soup"
+    }];
+
     const localVue = createLocalVue();
     let vuetify = new Vuetify(vuetifyConfig);
 
@@ -44,12 +56,8 @@ describe("Menu", () => {
                     "cover_image": "https://www.kitchensanctuary.com/wp-content/uploads/2019/09/Spaghetti-Bolognese-square-FS-0204-500x375.jpg",
                     "course": 0,
                     "isTodaysSpecial": false
-                },],
-                courses: [{
-                    "id": 0,
-                    "name": "Starters",
-                    "slug": "starters"
                 }],
+                courses: courses,
                 isLoading: false
             },
             localVue,
@@ -137,6 +145,40 @@ describe("Menu", () => {
             configurable: true,
             value: {back: original}
         })
+    });
+
+    it("doesn't render empty sections", () => {
+
+        const dishes = [{
+            "title": "Spaghetti Bolognese",
+            "description": "Spaghetti Bolognese",
+            "ingredients": "Spaghetti, Tomato, Ground Beef, Cheese" ,
+            "price": 69,
+            "cover_image": "https://www.kitchensanctuary.com/wp-content/uploads/2019/09/Spaghetti-Bolognese-square-FS-0204-500x375.jpg",
+            "course": 0,
+            "isTodaysSpecial": false
+        },
+        {
+            "title": "Spaghetti Bolognese",
+            "description": "Spaghetti Bolognese",
+            "ingredients": "Spaghetti, Tomato, Ground Beef, Cheese" ,
+            "price": 69,
+            "cover_image": "https://www.kitchensanctuary.com/wp-content/uploads/2019/09/Spaghetti-Bolognese-square-FS-0204-500x375.jpg",
+            "course": 0,
+            "isTodaysSpecial": false
+        }];
+
+        let app = mount(Menu, {
+            propsData: {
+                dishes: dishes,
+                courses: courses,
+                isLoading: false
+            },
+            localVue,
+            vuetify
+        });
+
+        expect(app.findAll(".v-expansion-panel").length).toBe(1);
     })
 
 })


### PR DESCRIPTION
Accordion menu no longer renders empty course sections (bug found by searchbar component). Added a new test for this behaviour to AccordionMenu test case

closes #64 